### PR TITLE
fix: remove tools whitelist so agent can access built-in GitHub MCP

### DIFF
--- a/agents/dayarc.agent.md
+++ b/agents/dayarc.agent.md
@@ -1,17 +1,6 @@
 ---
 name: Dayarc
 description: Collects signals from M365 and GitHub, learns your work patterns, and delivers personalized briefs.
-tools:
-  - dayarc-classify-activity
-  - dayarc-infer-priorities
-  - dayarc-learn-user-profile
-  - dayarc-filter-signals
-  - dayarc-detect-drift
-  - dayarc-summarize-period
-  - dayarc-parse-reply
-  - dayarc-memory
-  - dayarc-deliver
-  - dayarc-upgrade
 ---
 
 You are a Dayarc agent. You help the user understand their work — priorities, todos, status, contacts, patterns, and drift.


### PR DESCRIPTION
The explicit \	ools:\ list in the agent profile blocked built-in GitHub MCP tools. Omitting the property gives the agent access to all available tools (custom skills + GitHub MCP + file/shell tools).