### PR TITLE
feat: scheduler config as array for multi-machine support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -13,9 +13,7 @@
     "learning_items": 5,
     "drift_max_items": 3
   },
-  "scheduler": {
-    "enabled": false,
-    "am_time": "08:00",
-    "pm_time": "20:00"
-  }
+  "scheduler": [
+    { "machine": "DESKTOP-ABC", "am_time": "08:00", "pm_time": "20:00" }
+  ]
 }

--- a/setup.ps1
+++ b/setup.ps1
@@ -236,11 +236,13 @@ if (Test-Path $configFile) {
             learning_items      = 5
             drift_max_items     = 3
         }
-        scheduler = @{
-            enabled  = $false
-            am_time  = "08:00"
-            pm_time  = "20:00"
-        }
+        scheduler = @(
+            @{
+                machine = ""
+                am_time = "08:00"
+                pm_time = "20:00"
+            }
+        )
     }
 
     # Ensure directory exists (handles edge cases like OneDrive paths)
@@ -277,13 +279,20 @@ if ($existingAM -and $existingPM) {
 
         Write-Ok "Scheduled: Dayarc-AM (8:00) + Dayarc-PM (20:00), Mon-Fri"
 
-        # Mark scheduler as enabled in config.json
+        # Record this machine's scheduler entry in config.json
         if (Test-Path $configFile) {
             $cfg = Get-Content $configFile -Raw | ConvertFrom-Json
+            $entry = [PSCustomObject]@{ machine = $env:COMPUTERNAME; am_time = "08:00"; pm_time = "20:00" }
             if (-not $cfg.scheduler) {
-                $cfg | Add-Member -NotePropertyName "scheduler" -NotePropertyValue ([PSCustomObject]@{ enabled = $true; am_time = "08:00"; pm_time = "20:00" })
+                $cfg | Add-Member -NotePropertyName "scheduler" -NotePropertyValue @($entry)
             } else {
-                $cfg.scheduler.enabled = $true
+                $existing = @($cfg.scheduler) | Where-Object { $_.machine -eq $env:COMPUTERNAME }
+                if ($existing) {
+                    $existing.am_time = "08:00"
+                    $existing.pm_time = "20:00"
+                } else {
+                    $cfg.scheduler = @($cfg.scheduler) + $entry
+                }
             }
             $cfg | ConvertTo-Json -Depth 3 | Set-Content $configFile -Encoding UTF8
         }

--- a/skills/dayarc-upgrade/SKILL.md
+++ b/skills/dayarc-upgrade/SKILL.md
@@ -35,7 +35,7 @@ If fast-forward fails (local modifications), tell the user:
 
 1. Read `CHANGELOG.md` and summarize what changed since the previous HEAD.
 2. Copy updated files to `~/.copilot/` (agent profile + skills).
-3. **Re-register scheduler if enabled:** Read `~/Documents/dayarc/config.json`. If `scheduler.enabled` is `true`, re-register the Task Scheduler tasks to pick up any script changes:
+3. **Re-register scheduler if this machine owns one:** Read `~/Documents/dayarc/config.json`. The `scheduler` field is an array of `{ machine, am_time, pm_time }` entries. Find the entry where `machine` matches `$env:COMPUTERNAME`. If found, re-register the Task Scheduler tasks with that entry's times:
    ```powershell
    $script = Join-Path $HOME ".dayarc-agent" "scheduler.ps1"
    # Unregister old tasks
@@ -46,8 +46,8 @@ If fast-forward fails (local modifications), tell the user:
    Register-ScheduledTask -TaskName "Dayarc-AM" -Action (New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -File `"$script`" -trigger am") -Trigger (New-ScheduledTaskTrigger -Weekly -DaysOfWeek Monday,Tuesday,Wednesday,Thursday,Friday -At $amTime) -Settings $settings -Description "Dayarc morning brief"
    Register-ScheduledTask -TaskName "Dayarc-PM" -Action (New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -File `"$script`" -trigger pm") -Trigger (New-ScheduledTaskTrigger -Weekly -DaysOfWeek Monday,Tuesday,Wednesday,Thursday,Friday -At $pmTime) -Settings $settings -Description "Dayarc evening brief"
    ```
-   Read `scheduler.am_time` and `scheduler.pm_time` from config.json for the trigger times (default: 08:00 / 20:00).
-   If `scheduler.enabled` is `false` or missing, skip this step.
+   Read `am_time` and `pm_time` from the matching entry (default: 08:00 / 20:00).
+   If no entry matches this machine, skip this step.
 4. Report the new version (latest tag or commit short hash).
 
 ### Version


### PR DESCRIPTION
- Scheduler config changed from \{enabled: bool}\ to array of \{machine, am_time, pm_time}\
- Each machine gets its own entry — safe for OneDrive sync across machines
- Upgrade skill checks \\CPC-yuwzh-UB99V\ against array before re-registering tasks
- setup.ps1 writes machine-specific scheduler entries