### PR TITLE
fix: PS 5.1 compatibility for scheduler.ps1

### DIFF
--- a/scheduler.ps1
+++ b/scheduler.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Dayarc — Scheduler Script
 .DESCRIPTION
@@ -23,7 +23,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 $agentDir = Join-Path $HOME ".dayarc-agent"
-$profileDir = Join-Path $HOME "Documents" "dayarc"
+$profileDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) "dayarc"
 
 function Is-LastWorkday {
     param([DateTime]$date)
@@ -39,29 +39,32 @@ $today = Get-Date
 
 Write-Host "[Dayarc] Trigger: $trigger | Date: $($today.ToString('yyyy-MM-dd'))"
 
+Push-Location $profileDir
+
 if ($trigger -eq "am") {
     Write-Host "[Dayarc] Running AM brief..."
-    copilot --agent=dayarc --prompt "$agentDir\prompts\am.md" --cwd $profileDir
+    copilot --agent=dayarc --prompt "$agentDir\prompts\am.md"
 }
 
 if ($trigger -eq "pm") {
     Write-Host "[Dayarc] Running PM brief..."
-    copilot --agent=dayarc --prompt "$agentDir\prompts\pm.md" --cwd $profileDir
+    copilot --agent=dayarc --prompt "$agentDir\prompts\pm.md"
 
     if ($today.DayOfWeek -eq [DayOfWeek]::Friday) {
-        Write-Host "[Dayarc] Friday — running Weekly brief..."
-        copilot --agent=dayarc --prompt "$agentDir\prompts\weekly.md" --cwd $profileDir
+        Write-Host "[Dayarc] Friday -- running Weekly brief..."
+        copilot --agent=dayarc --prompt "$agentDir\prompts\weekly.md"
 
         if (Is-LastWorkday $today) {
-            Write-Host "[Dayarc] Last workday of month — running Monthly brief..."
-            copilot --agent=dayarc --prompt "$agentDir\prompts\monthly.md" --cwd $profileDir
+            Write-Host "[Dayarc] Last workday of month -- running Monthly brief..."
+            copilot --agent=dayarc --prompt "$agentDir\prompts\monthly.md"
         }
-    }
-    elseif (Is-LastWorkday $today) {
-        Write-Host "[Dayarc] Last workday of month (non-Friday) — running Weekly + Monthly..."
-        copilot --agent=dayarc --prompt "$agentDir\prompts\weekly.md" --cwd $profileDir
-        copilot --agent=dayarc --prompt "$agentDir\prompts\monthly.md" --cwd $profileDir
+    } elseif (Is-LastWorkday $today) {
+        Write-Host "[Dayarc] Last workday of month (non-Friday) -- running Weekly + Monthly..."
+        copilot --agent=dayarc --prompt "$agentDir\prompts\weekly.md"
+        copilot --agent=dayarc --prompt "$agentDir\prompts\monthly.md"
     }
 }
+
+Pop-Location
 
 Write-Host "[Dayarc] Done."


### PR DESCRIPTION
## Problem

Task Scheduler runs \powershell.exe\ (PS 5.1), but \scheduler.ps1\ had four issues that caused it to silently fail every scheduled run.

## Root Cause

| # | Bug | Why it broke in PS 5.1 |
|---|---|---|
| 1 | Em dash (U+2014) in UTF-8-no-BOM file | Byte 0x94 decoded as right double quote in Win-1252, breaking string parsing |
| 2 | \Join-Path\ with 3 positional args | Only supported in PS 6+ |
| 3 | \--cwd\ copilot CLI flag | Not a valid flag in copilot CLI |
| 4 | \}\ on separate line from \lseif\ | Parse error in PS 5.1 |

## Fix

- Added UTF-8 BOM + replaced em dashes with ASCII \--\
- Used \[Environment]::GetFolderPath('MyDocuments')\ (also fixes OneDrive-redirected Documents)
- Replaced \--cwd\ with \Push-Location\ / \Pop-Location\
- Moved \} elseif\ to same line

All changes are backward-compatible with PS 7.

## Testing

- Verified parse succeeds in PS 5.1 via \[Parser]::ParseFile()\ (0 errors)
- Task Scheduler test fire: task transitions to Running (result 267009)