### PR TITLE
fix: explicitly query GitHub mentions, review requests, and assignments

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,7 +2,7 @@
   "user": {
     "display_name": "Your Name",
     "email": "you@example.com",
-    "github_username": "your-handle"
+    "github_usernames": ["your-handle"]
   },
   "preferences": {
     "brief_max_items": 15,

--- a/prompts/am.md
+++ b/prompts/am.md
@@ -3,7 +3,7 @@
 You are Dayarc running a **scheduled AM brief**.
 Follow steps in order. Do not skip steps. Read memory-schemas.md before writing any JSON.
 
-**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_username.
+**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_usernames (array — query all accounts).
 
 **Idempotency:** Check `~/Documents/dayarc/memory/runs/{today}-am.json`. If it exists, STOP — already ran today.
 
@@ -36,10 +36,17 @@ Query **Work IQ** (ask_work_iq) for overnight/new signals:
 - "What emails arrived since Friday evening?"
 - "What Teams messages arrived since Friday evening?"
 
-Query **GitHub MCP**:
-- Notifications since last check
-- PRs awaiting my review
-- Issues assigned to me
+Query **GitHub MCP** (authenticated account):
+- Notifications since last check — specifically look for:
+  - `reason:mention` — someone @mentioned the user
+  - `reason:review_requested` — someone requested a PR review
+  - `reason:assign` — an issue or PR was assigned to the user
+- PRs awaiting my review (search: `is:pr review-requested:{username}` for **each** github_usernames entry)
+- Issues assigned to me (search: `is:issue assignee:{username}` for **each** github_usernames entry)
+
+**Note:** GitHub MCP can only fetch notifications for the active `gh` account. For other accounts (e.g. EMU/corp), GitHub sends notification emails — Work IQ captures these via Outlook. Cross-reference both sources to avoid missing items.
+
+These are high-priority signals — surface them prominently even if other data is sparse.
 
 ## Step 2: READ
 

--- a/prompts/monthly.md
+++ b/prompts/monthly.md
@@ -3,7 +3,7 @@
 You are Dayarc running a **scheduled Monthly brief**.
 Follow steps in order. Do not skip steps. Read memory-schemas.md before writing any JSON.
 
-**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_username.
+**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_usernames (array — query all accounts).
 
 **Idempotency:** Check `~/Documents/dayarc/memory/runs/{today}-monthly.json`. If it exists, STOP — already ran.
 

--- a/prompts/pm.md
+++ b/prompts/pm.md
@@ -3,7 +3,7 @@
 You are Dayarc running a **scheduled PM brief**.
 Follow steps in order. Do not skip steps. Read memory-schemas.md before writing any JSON.
 
-**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_username.
+**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_usernames (array — query all accounts).
 
 **Idempotency:** Check `~/Documents/dayarc/memory/runs/{today}-pm.json`. If it exists, STOP — already ran today.
 
@@ -33,11 +33,14 @@ Query **Work IQ** (ask_work_iq) for today's data:
 - "What meetings did I have today?"
 - "What documents did I edit today?"
 
-Query **GitHub MCP** for today's data:
+Query **GitHub MCP** (authenticated account) for today's data:
 - Commits authored today
 - PRs opened or reviewed today
 - Issues commented on or closed today
 - Reviews submitted today
+- **Notifications:** search for `reason:mention`, `reason:review_requested`, `reason:assign` since this morning — these are high-priority signals the user may have missed
+
+**Note:** For non-active GitHub accounts (e.g. EMU/corp), notification emails are captured by Work IQ via Outlook. Cross-reference both sources.
 
 ## Step 2: READ
 

--- a/prompts/weekly.md
+++ b/prompts/weekly.md
@@ -3,7 +3,7 @@
 You are Dayarc running a **scheduled Weekly brief**.
 Follow steps in order. Do not skip steps. Read memory-schemas.md before writing any JSON.
 
-**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_username.
+**User identity:** Read `~/Documents/dayarc/config.json` for display_name, email, and github_usernames (array — query all accounts).
 
 **Idempotency:** Check `~/Documents/dayarc/memory/runs/{today}-weekly.json`. If it exists, STOP — already ran.
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -219,13 +219,14 @@ if (Test-Path $configFile) {
 
     $displayName = Read-Host "    Full name as it appears in @mentions (e.g. Yu Zhou, not a nickname)"
     $email       = Read-Host "    Work email address"
-    $ghUser      = Read-Host "    GitHub username"
+    $ghUsers     = Read-Host "    GitHub username(s), comma-separated if multiple"
+    $ghUserList  = @($ghUsers -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
 
     $config = @{
         user = @{
-            display_name    = $displayName
-            email           = $email
-            github_username = $ghUser
+            display_name     = $displayName
+            email            = $email
+            github_usernames = $ghUserList
         }
         preferences = @{
             brief_max_items     = 15

--- a/skills/dayarc-filter-signals/SKILL.md
+++ b/skills/dayarc-filter-signals/SKILL.md
@@ -19,7 +19,7 @@ Incoming signals (new emails, Teams messages, GitHub notifications), user profil
 ```
 
 ## Instructions
-1. Auto-pass (relevance=1.0): flagged, saved, or direct @mention. pass_reason = "flagged"/"saved"/"direct mention".
+1. Auto-pass (relevance=1.0): flagged, saved, direct @mention, GitHub review_requested, GitHub assigned. pass_reason = "flagged"/"saved"/"direct mention"/"review requested"/"assigned".
 2. Others: score 0-1 based on overlap with profile's focus_areas, key_contacts, active_threads.
 3. Include if relevance ≥ 0.4. Write pass_reason explaining which profile element matched.
 4. Below threshold: silently drop.


### PR DESCRIPTION
AM/PM prompts now instruct the agent to search for specific GitHub notification reasons (\mention\, \eview_requested\, \ssign\) with concrete search queries. Filter-signals skill auto-passes these at relevance=1.0.