### PR TITLE
fix: mitigate broken Teams meeting chat links

### DIFF
--- a/agents/dayarc.agent.md
+++ b/agents/dayarc.agent.md
@@ -28,6 +28,7 @@ When invoked with a plan prompt (pm.md, am.md, weekly.md, monthly.md), follow th
 
 ## Rules
 - Every brief item must describe *what* it is + a source breadcrumb (link, thread, channel).
+- **Breadcrumb quality:** Teams meeting chat links (`19:meeting_...@thread.v2`) frequently break after the meeting ends. When you encounter one, always include fallback context (meeting title, date, participants) so the user can find the item without the link. Mark with ⚠️.
 - Read memory-schemas.md before writing any JSON file.
 - Never invent data. Only report what signals and memory show.
 - Never draft replies or take write actions on external systems.

--- a/skills/dayarc-classify-activity/SKILL.md
+++ b/skills/dayarc-classify-activity/SKILL.md
@@ -22,5 +22,6 @@ Raw signals from Work IQ + GitHub for the day.
 2. Cluster by work theme (e.g., "auth migration", "team coordination", "code review").
 3. Within each cluster, write one sentence per activity describing *what* was done.
 4. Every activity MUST have a `source_breadcrumb` — a link, thread subject, or channel name. If unavailable: "source unavailable".
-5. Estimate effort per cluster: "high", "medium", or "low" relative to the day.
-6. Max 15 activities total across all groups.
+5. **Teams meeting links** (`19:meeting_...@thread.v2`): these often break after the meeting ends. When a breadcrumb contains a meeting thread link, add a fallback — include the meeting title, date, and participant names so the user can locate the context manually. Mark the breadcrumb with `⚠️` to indicate it may not resolve.
+6. Estimate effort per cluster: "high", "medium", or "low" relative to the day.
+7. Max 15 activities total across all groups.


### PR DESCRIPTION
Closes #32

Work IQ returns Teams meeting thread links (\19:meeting_...@thread.v2\) that frequently break after the meeting ends.

**Mitigations:**
- Agent profile: breadcrumb quality rule — always include fallback context (meeting title, date, participants) for meeting links, marked with ⚠️
- Classify-activity skill: detect meeting thread URLs, add manual-lookup fallback context

Root cause is in Work IQ (M365 Copilot), not Dayarc. These mitigations ensure users can still find the source even when links break.