### PR TITLE
fix: remove labels from issue creation — triage bot handles labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug Report
 about: Report a problem with Dayarc briefs, skills, or delivery
 title: "[Bug] "
-labels: bug
 ---
 
 ## What happened

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature Request
 about: Suggest a new feature or improvement for Dayarc
 title: "[Feature] "
-labels: enhancement
 ---
 
 ## What

--- a/skills/dayarc-report-issue/SKILL.md
+++ b/skills/dayarc-report-issue/SKILL.md
@@ -21,8 +21,9 @@ User asks to report a bug, file an issue, or request a feature for Dayarc.
 5. **Confirm** — Wait for explicit "yes" before filing. Never file without confirmation.
 6. **File** — Run:
    ```
-   gh issue create --repo YuiZhou/dayarc-agent --title "{title}" --body "{body}" --label "{bug|enhancement}"
+   gh issue create --repo YuiZhou/dayarc-agent --title "{title}" --body "{body}"
    ```
+   Do NOT add `--label`. Users don't have label permissions — the triage bot handles labeling.
 7. **Report** — Show the issue URL to the user.
 
 ## Issue Body Format


### PR DESCRIPTION
Users don't have label permissions on the repo. Removed:
- \--label\ flag from report-issue skill's \gh issue create\ command
- \labels:\ frontmatter from bug_report.md and feature_request.md

The triage bot already applies bug/enhancement labels via classification.