### PR TITLE
fix: prevent CI hangs + use GITHUB_TOKEN for PR creation

### DIFF
--- a/.github/prompts/coding-prompt.md
+++ b/.github/prompts/coding-prompt.md
@@ -42,3 +42,5 @@ You must NEVER modify:
 - Make minimal, targeted changes — don't rewrite entire files unnecessarily
 - Feature requests: only fix if the change is trivially additive. Otherwise write `unable.md`.
 - Always reference the relevant spec/design section in `summary.md`
+- **NEVER ask the user questions or wait for input.** You are running unattended in CI. If something is ambiguous, make your best judgment or write `unable.md`.
+- Do NOT use interactive tools or commands that require confirmation.

--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -163,6 +163,7 @@ jobs:
 
       # Step 5: Run Copilot CLI — let it edit files directly
       - name: Run Copilot CLI
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.COPILOT_PAT }}
         run: |
@@ -234,7 +235,7 @@ jobs:
         if: steps.detect.outputs.action == 'fix'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           ISSUE_NUM="${{ steps.resolve.outputs.number }}"
           SLUG="${{ steps.resolve.outputs.slug }}"


### PR DESCRIPTION
- Prompt forbids asking user questions or using interactive commands
- 10-minute timeout on Copilot CLI step
- Use GITHUB_TOKEN for branch push + PR (COPILOT_PAT lacks PR permission)