### PR TITLE
fix: force-push for branch collisions

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -260,7 +260,9 @@ jobs:
           fi
 
           git commit -m "fix: #${ISSUE_NUM} — ${SUMMARY}"
-          git push origin "$BRANCH"
+
+          # Handle branch collision — force push if branch exists
+          git push origin "$BRANCH" --force
 
           # Build PR body
           PR_BODY="## Automated Fix for #${ISSUE_NUM}


### PR DESCRIPTION
Handle re-runs where branch already exists from previous attempt.