### PR TITLE
fix: prevent shell injection from triage affected_area

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -91,8 +91,9 @@ jobs:
       # Step 3: Read source files based on affected area
       - name: Read source files
         id: sources
+        env:
+          AFFECTED: ${{ steps.gather.outputs.affected_area }}
         run: |
-          AFFECTED="${{ steps.gather.outputs.affected_area }}"
           SOURCE_CONTENT=""
 
           # Try to find the skill file from affected_area


### PR DESCRIPTION
Triage bot affected_area can contain backticks. Use env var instead of direct interpolation.