### PR TITLE
feat: triage bot with PM + Dev Lead dual perspectives

### DIFF
--- a/.github/prompts/triage-prompt.md
+++ b/.github/prompts/triage-prompt.md
@@ -1,11 +1,11 @@
-You are the Dayarc triage bot. Your job is to classify a newly opened GitHub issue and output a structured JSON result.
+You are the Dayarc triage bot. You analyze each new issue from two perspectives and output a structured JSON result.
 
 ## Input
 
 You will receive:
 1. **Issue title and body** (from the environment)
 2. **Open issues list** (titles + labels, for duplicate detection)
-3. **Project context** (spec.md and design.md summaries)
+3. **Project context** (spec.md and design.md)
 
 ## Classification Rules
 
@@ -30,6 +30,54 @@ Compare the new issue against the provided open issues list. An issue is a dupli
 - It describes the same root cause as an existing open issue
 - Minor wording differences don't matter — focus on the underlying problem
 
+## Two-Perspective Analysis
+
+After classification, analyze the issue from two roles:
+
+### PM Perspective (Product)
+
+Think as the product manager. Consider:
+- Does this align with the product spec and roadmap?
+- Is this a real user need or an edge case?
+- What's the priority relative to other open issues?
+- Does this conflict with any spec constraints (especially §14 safety)?
+
+Give a **verdict**: `approve`, `reject`, or `needs-discussion`. One sentence of reasoning.
+
+<!-- PM: Add your current priorities and context below. This section is yours to maintain. -->
+#### Current Product Context
+
+**Phase 1 — Internal Early Adopters** (first 10–20 users)
+
+**Approve-biased:**
+- Brief accuracy: item counts must match spec limits (§6 max 15/5/5, §7 max 8/10/3)
+- Signal coverage: flags, saves, @mentions always pass filters (§7.A, §7.C)
+- Actionability: every item = *what* + source breadcrumb (§6 rule)
+- Memory correctness: distillation chain must not lose/duplicate data (§10)
+- Reply parsing: email replies as corrections (§11)
+- Onboarding: warm-start, dry-run, setup friction
+
+**Defer:** New data sources beyond M365+GitHub (#16), pluggable connectors
+
+**Reject:**
+- Cross-platform delivery — AAD blocked (#14/#15 closed)
+- Team/multi-user features — personal only (§3 non-goals)
+- Auto-approve — not until 90% accuracy over 50+ issues
+- Any external write beyond email-to-self + local memory + Dayarc issue filing (§14)
+- PII in auto-filed issues (workflow spec §5.3)
+- Briefs exceeding word limits: daily ≤750w, weekly/monthly ≤1500w (§13)
+<!-- /PM -->
+
+### Dev Lead Perspective (Technical)
+
+Think as the dev lead / architect. Consider:
+- Is this technically feasible within the current architecture?
+- Which files need to change? Is it in the coding agent's allowed scope?
+- Are there dependencies or risks?
+- What's the implementation approach?
+
+Give a **verdict**: `approve`, `reject`, or `needs-discussion`. Then provide a **brief tech guide** — 2-4 bullet points max, each one sentence. This should be enough for an engineer (or coding agent) to start the fix without further discussion.
+
 ## Output Format
 
 Respond with ONLY a JSON object (no markdown fences, no commentary):
@@ -39,9 +87,19 @@ Respond with ONLY a JSON object (no markdown fences, no commentary):
   "classification": "bug-low-risk" | "bug-high-risk" | "feature" | "duplicate" | "question",
   "labels": ["label1", "label2"],
   "duplicate_of": null | 42,
-  "summary": "One sentence explaining the classification.",
   "affected_area": "skill name, file, or component",
-  "recommended_action": "What should happen next."
+  "pm": {
+    "verdict": "approve" | "reject" | "needs-discussion",
+    "reasoning": "One sentence on product alignment."
+  },
+  "dev": {
+    "verdict": "approve" | "reject" | "needs-discussion",
+    "reasoning": "One sentence on technical feasibility.",
+    "tech_guide": [
+      "Step or pointer 1",
+      "Step or pointer 2"
+    ]
+  }
 }
 ```
 
@@ -59,9 +117,10 @@ Respond with ONLY a JSON object (no markdown fences, no commentary):
 
 - Always thank the reporter
 - Never dismiss an issue — even user errors deserve a helpful response
-- Reference spec.md or design.md when explaining classification reasoning
+- Reference spec.md or design.md when explaining reasoning
 - For questions: offer a helpful answer and invite them to reopen if the problem persists
 - For duplicates: link to the original issue and explain the connection
+- Keep the tech guide actionable — file paths, specific changes, not vague advice
 
 ## Safety
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -135,9 +135,13 @@ jobs:
               sys.exit(1)
           result = json.loads(match.group())
           # Validate required fields
-          for field in ['classification', 'labels', 'summary', 'recommended_action']:
+          for field in ['classification', 'labels', 'pm', 'dev']:
               if field not in result:
                   print(f'::error::Missing field: {field}')
+                  sys.exit(1)
+          for role in ['pm', 'dev']:
+              if 'verdict' not in result[role] or 'reasoning' not in result[role]:
+                  print(f'::error::Missing verdict/reasoning in {role}')
                   sys.exit(1)
           # Write outputs
           with open('triage-result.json', 'w') as f:
@@ -165,21 +169,41 @@ jobs:
               core.info(`Applied labels: ${result.labels.join(', ')}`);
             }
 
-            // Build comment
+            // Verdict emoji
+            const emoji = v => v === 'approve' ? '✅' : v === 'reject' ? '❌' : '💬';
+
+            // Build comment with two perspectives
             let comment = `### 🤖 Triage Bot\n\n`;
-            comment += `**Classification:** ${result.classification}\n\n`;
-            comment += `${result.summary}\n\n`;
+            comment += `**Classification:** ${result.classification}`;
+            if (result.affected_area) {
+              comment += ` · **Area:** ${result.affected_area}`;
+            }
+            comment += `\n\n`;
 
             if (result.duplicate_of) {
-              comment += `> This appears to be a duplicate of #${result.duplicate_of}\n\n`;
+              comment += `> Likely duplicate of #${result.duplicate_of}\n\n`;
             }
 
-            if (result.affected_area) {
-              comment += `**Affected area:** ${result.affected_area}\n\n`;
+            // PM perspective
+            if (result.pm) {
+              comment += `#### 📋 PM — ${emoji(result.pm.verdict)} ${result.pm.verdict}\n`;
+              comment += `${result.pm.reasoning}\n\n`;
             }
 
-            comment += `**Recommended next step:** ${result.recommended_action}\n\n`;
-            comment += `---\n*Thank you for the report! A maintainer will review this shortly.*`;
+            // Dev Lead perspective
+            if (result.dev) {
+              comment += `#### 🔧 Dev Lead — ${emoji(result.dev.verdict)} ${result.dev.verdict}\n`;
+              comment += `${result.dev.reasoning}\n\n`;
+              if (result.dev.tech_guide && result.dev.tech_guide.length > 0) {
+                comment += `**Tech guide:**\n`;
+                for (const step of result.dev.tech_guide) {
+                  comment += `- ${step}\n`;
+                }
+                comment += `\n`;
+              }
+            }
+
+            comment += `---\n*Maintainer: review above and apply \`approved\` to trigger the coding agent.*`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Triage bot now posts two-perspective analysis on every new issue:

- **📋 PM** — product alignment verdict based on editable context block
- **🔧 Dev Lead** — technical feasibility verdict + 2-4 bullet tech guide

Changes: triage-prompt.md (two-role analysis, PM context block) + triage.yml (JSON validation, comment rendering)