### PR TITLE
fix(#51): harden Step 0 reply processing and Parse-Reply skill

### DIFF
--- a/prompts/am.md
+++ b/prompts/am.md
@@ -11,15 +11,23 @@ Follow steps in order. Do not skip steps. Read memory-schemas.md before writing 
 
 ## Step 0: CHECK REPLIES
 
-Search Outlook for replies to previous briefs:
-- Subject contains `RE: ☀️` or `RE: 🌙` (brief reply)
-- Received since last run
+**0a. Find the cutoff timestamp.** Read the most recent run tag via **dayarc-memory**:
+- AM brief: read `runs/{yesterday}-pm.json` (last PM run)
+- If missing, fall back to `runs/{yesterday}-am.json`, then 24 hours ago.
+- Extract the `timestamp` field — this is your "since" cutoff.
 
-For each reply found:
+**0b. Query for reply emails.** Use **Work IQ** with this exact prompt:
+> Show me emails I received with subjects matching any of: `RE: ☀️`, `RE: 🌙`, `RE: 📊`, `RE: 📅` since {cutoff timestamp}
+
+**0c. Process each reply found:**
 1. Use **parse_reply** skill to extract corrections.
 2. If corrections found, read the latest daily profile via **dayarc-memory**.
 3. Apply corrections to the profile.
 4. Write updated profile back via **dayarc-memory**.
+5. Set a flag: `replies_applied = true` with a summary of what changed.
+
+**0d. Acknowledgment.** If `replies_applied`, include at the top of the brief output:
+> ✅ Applied corrections from your reply: {summary of changes}
 
 If no replies found, continue to Step 1.
 

--- a/prompts/pm.md
+++ b/prompts/pm.md
@@ -11,15 +11,23 @@ Follow steps in order. Do not skip steps. Read memory-schemas.md before writing 
 
 ## Step 0: CHECK REPLIES
 
-Search Outlook for replies to previous briefs:
-- Subject contains `RE: ☀️` or `RE: 🌙` (brief reply)
-- Received since last run
+**0a. Find the cutoff timestamp.** Read the most recent run tag via **dayarc-memory**:
+- PM brief: read `runs/{today}-am.json` (last AM run)
+- If missing, fall back to `runs/{yesterday}-pm.json`, then 12 hours ago.
+- Extract the `timestamp` field — this is your "since" cutoff.
 
-For each reply found:
+**0b. Query for reply emails.** Use **Work IQ** with this exact prompt:
+> Show me emails I received with subjects matching any of: `RE: ☀️`, `RE: 🌙`, `RE: 📊`, `RE: 📅` since {cutoff timestamp}
+
+**0c. Process each reply found:**
 1. Use **parse_reply** skill to extract corrections.
 2. If corrections found, read the latest daily profile via **dayarc-memory**.
 3. Apply corrections (mark_done, remove, add_priority, correct) to the profile.
 4. Write updated profile back via **dayarc-memory**.
+5. Set a flag: `replies_applied = true` with a summary of what changed.
+
+**0d. Acknowledgment.** If `replies_applied`, include at the top of the brief output:
+> ✅ Applied corrections from your reply: {summary of changes}
 
 If no replies found, continue to Step 1.
 

--- a/skills/dayarc-parse-reply/SKILL.md
+++ b/skills/dayarc-parse-reply/SKILL.md
@@ -6,6 +6,16 @@ description: Extract corrections from user's reply to a brief email.
 ## Input
 Text of the user's reply to a brief email.
 
+## Pre-processing
+
+Before parsing, strip everything below the first occurrence of any of these separator patterns (original email quote):
+- A line starting with `From:`
+- A line starting with `Sent:`
+- A line that is exactly `---` or `___` or `***`
+- A line starting with `>` followed by `On ... wrote:`
+
+Only parse the text **above** the first separator.
+
 ## Output (JSON)
 ```json
 {
@@ -18,7 +28,50 @@ Text of the user's reply to a brief email.
 ```
 
 ## Instructions
-1. Parse natural language corrections: "X is done", "drop X", "add Y as priority", "X is wrong".
-2. Map to actions: mark_done, remove, add_priority, correct.
-3. Ignore non-actionable replies: "thanks", "looks good", "ok".
-4. If no actionable content found, return empty corrections array.
+1. Parse natural language corrections. Map to actions:
+   - **mark_done**: "X is done", "finished X", "completed X", "X is complete"
+   - **remove**: "drop X", "remove X", "X is no longer relevant", "ignore X"
+   - **add_priority**: "add X as priority", "X should be tracked", "new priority: X"
+   - **correct**: "X is wrong, it should be Y", "actually X is ...", "correction: ..."
+2. Ignore non-actionable replies: "thanks", "looks good", "ok", "got it", "👍".
+3. If no actionable content found, return empty corrections array.
+
+## Examples
+
+**Single correction:**
+```
+Input: "Auth migration is done, shipped yesterday"
+Output: { "corrections": [{ "action": "mark_done", "target": "auth migration", "detail": "Shipped yesterday" }] }
+```
+
+**Multiple corrections:**
+```
+Input: "Drop the perf review prep — it got cancelled. Also add quarterly OKR planning as a new priority."
+Output: {
+  "corrections": [
+    { "action": "remove", "target": "perf review prep", "detail": "Cancelled" },
+    { "action": "add_priority", "target": "quarterly OKR planning", "detail": "New priority from user" }
+  ]
+}
+```
+
+**Quoted reply (strip original):**
+```
+Input:
+"Cost optimization is done
+
+From: Dayarc <myself@company.com>
+Sent: Monday, March 24, 2026 8:00 PM
+Subject: 🌙 PM Brief — Mon 24 Mar
+
+Section A: What you accomplished today
+..."
+
+Output: { "corrections": [{ "action": "mark_done", "target": "cost optimization", "detail": "User confirmed done" }] }
+```
+
+**No-op reply:**
+```
+Input: "Looks good, thanks!"
+Output: { "corrections": [] }
+```


### PR DESCRIPTION
## Changes

### AM/PM prompts (Step 0: CHECK REPLIES)
- **Cutoff timestamp**: Read previous run tag to get exact since-time
- **Explicit Work IQ query**: All 4 emoji patterns (AM, PM, Weekly, Monthly)
- **Acknowledgment**: Brief now shows 'Applied corrections from your reply' when corrections processed

### Parse-Reply skill
- **Pre-processing**: Strip quoted original email below From:/Sent:/--- separators
- **Detailed action mapping**: Explicit trigger phrases for each action type
- **4 worked examples**: Single correction, multi-correction, quoted-reply stripping, no-op

## Why
Step 0 was underspecified — the LLM had to guess the Work IQ query and didn't know the cutoff timestamp. Parse-Reply had no examples for the LLM to learn from. Replies were silently dropped.

Closes #51