### PR TITLE
fix: widen scope guard + pass unable reason to issue comment

### DIFF
--- a/.github/prompts/coding-prompt.md
+++ b/.github/prompts/coding-prompt.md
@@ -27,12 +27,13 @@ You will receive:
 You may ONLY modify files matching these patterns:
 - `skills/*/SKILL.md`
 - `skills/*/templates/*.hbs`
+- `prompts/*.md` (plan prompts)
+- `memory-schemas.md`
 - `README.md`, `USAGE.md`, `CONTRIBUTING.md`
 
 You must NEVER modify:
-- `memory-schemas.md`, `config.example.json`
+- `config.example.json`
 - `agents/dayarc.agent.md`
-- `prompts/*.md` (plan prompts)
 - `setup.ps1`, `scheduler.ps1`
 - `.github/workflows/*`, `.github/prompts/*`
 - `spec.md`, `design.md`

--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -210,6 +210,11 @@ jobs:
 
           if [ -z "$CHANGED" ] && [ -n "$UNABLE_CONTENT" ]; then
             echo "action=unable" >> "$GITHUB_OUTPUT"
+            {
+              echo "unable<<UNABLE_DELIM"
+              echo "$UNABLE_CONTENT"
+              echo "UNABLE_DELIM"
+            } >> "$GITHUB_OUTPUT"
             echo "Agent determined it cannot fix this issue"
             echo "$UNABLE_CONTENT"
           elif [ -z "$CHANGED" ]; then
@@ -227,8 +232,8 @@ jobs:
         run: |
           BASELINE="${{ steps.baseline.outputs.sha }}"
           CHANGED=$(git diff --name-only "$BASELINE")
-          ALLOWED="^(skills/.*/SKILL\.md|skills/.*/templates/.*\.hbs|README\.md|USAGE\.md|CONTRIBUTING\.md)$"
-          BLOCKED=".github/workflows/ .github/prompts/"
+          ALLOWED="^(skills/.*/SKILL\.md|skills/.*/templates/.*\.hbs|prompts/.*\.md|memory-schemas\.md|README\.md|USAGE\.md|CONTRIBUTING\.md)$"
+          BLOCKED=".github/workflows/ .github/prompts/ setup\.ps1 scheduler\.ps1 package\.json"
 
           VIOLATIONS=""
           for file in $CHANGED; do
@@ -327,9 +332,10 @@ jobs:
       - name: Comment on issue
         if: always()
         uses: actions/github-script@v7
+        env:
+          UNABLE_REASON: ${{ steps.detect.outputs.unable }}
         with:
           script: |
-            const fs = require('fs');
             const issueNumber = parseInt('${{ steps.resolve.outputs.number }}');
             const action = '${{ steps.detect.outputs.action }}' || 'none';
 
@@ -349,10 +355,7 @@ jobs:
                 comment += '⚠️ Fix was generated but PR creation failed. Check the workflow logs.';
               }
             } else if (action === 'unable') {
-              let reason = 'The fix requires changes outside the coding agent scope.';
-              try {
-                reason = fs.readFileSync('unable.md', 'utf8');
-              } catch {}
+              const reason = process.env.UNABLE_REASON || 'The fix requires changes outside the coding agent scope.';
               comment += `The coding agent determined it **cannot automatically fix** this issue.\n\n`;
               comment += `${reason}\n\n`;
               comment += 'A maintainer will need to address this manually.';


### PR DESCRIPTION
## Changes

### 1. Scope guard widened
**Added to allowlist:** `prompts/*.md`, `memory-schemas.md`
**Added to blocklist:** `setup.ps1`, `scheduler.ps1`, `package.json`

The agent was failing scope guard when fixing prompt-related issues (e.g. editing `prompts/pm.md` or `memory-schemas.md`). These are legitimate edit targets.

### 2. Unable reason passed through outputs
**Before:** Comment step read `unable.md` from disk — but detect step deletes it during cleanup → generic fallback message
**After:** Detect step writes content to `steps.detect.outputs.unable` → comment step reads from `process.env.UNABLE_REASON`

### 3. Coding prompt updated
Scope guard section in `.github/prompts/coding-prompt.md` updated to match the new allowlist.

## Evidence
- Run 23679618467: scope guard blocked `memory-schemas.md` (now allowed)
- Run 23679618155: scope guard blocked `prompts/pm-dryrun.md` (now allowed)
- Run 23679618035: unable comment posted without details (now fixed)