### PR TITLE
fix: squash agent commits before creating PR branch

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -272,7 +272,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
 
-          # Stage only tracked file changes (not agent artifacts)
+          # Squash all changes since baseline into the working tree.
+          # Copilot CLI may have committed changes directly, so git add -A
+          # alone would find "nothing to commit". Soft-reset collapses
+          # agent commits + unstaged edits into staged changes.
+          BASELINE="${{ steps.baseline.outputs.sha }}"
+          git reset --soft "$BASELINE"
+
           git add -A
           # Remove any agent artifacts that got staged
           git reset HEAD -- summary.md unable.md coding-input.md source-files.txt copilot-output.txt copilot-stderr.log 2>/dev/null || true


### PR DESCRIPTION
## Bug

When Copilot CLI commits changes directly (via `git add` + `git commit`), the PR step runs `git add -A` and gets "nothing to commit, working tree clean" — failing the workflow.

This affected 2 of 3 latest runs (Warm-start #9, Reply feedback #12).

## Fix

Add `git reset --soft $BASELINE` after creating the branch. This collapses any agent commits + unstaged edits back into staged changes, letting the PR step create one clean commit regardless of whether the agent committed or not.

## Third run (Guided dry-run)
Scope guard correctly blocked `setup.ps1` — working as intended.