### PR TITLE
feat(#10): guided dry-run brief after setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `setup.ps1` — One-line installer (`irm .../setup.ps1 | iex`), upgrade, and uninstall
+- `setup.ps1` dry-run offer — After install, prompts user to preview their first brief (reuses `pm.md` with side effects disabled)
 - `dayarc-upgrade` skill — Conversational agent updates ("Update your skills")
 - `dayarc-report-issue` skill — File bug reports and feature requests on the Dayarc repo
 - `.github/ISSUE_TEMPLATE/` — Bug report and feature request templates

--- a/setup.ps1
+++ b/setup.ps1
@@ -315,3 +315,27 @@ Write-Host   "  Agent:    $agentDir"
 Write-Host   "  Data:     $dataDir"
 Write-Host   "  Start:    copilot --agent=dayarc"
 Write-Host   ""
+
+# ── Dry-run preview ──────────────────────────────────────────────────────────
+
+Write-Step "Preview brief (optional)"
+Write-Host "  Your first real brief will arrive at 8 PM." -ForegroundColor DarkGray
+Write-Host "  Want to see a preview now? This won't send email or write any data." -ForegroundColor DarkGray
+Write-Host ""
+
+$dryrun = Read-Host "    Run a dry-run PM brief now? [y/N]"
+if ($dryrun -match '^[Yy]') {
+    Write-Host ""
+    Write-Host "  Running dry-run brief (this may take 1-2 minutes)..." -ForegroundColor Cyan
+    Write-Host ""
+    $pmPrompt = Get-Content (Join-Path $agentDir "prompts\pm.md") -Raw
+    $dryrunPrompt = "## DRY RUN MODE`nThis is a preview. Follow the plan below but: skip the idempotency check, do NOT send email (skip Step 5), do NOT write memory files or run tags (skip Step 4). Output the brief to the terminal only. After displaying the brief, ask if the user wants to adjust anything.`n`n$pmPrompt"
+    Push-Location $dataDir
+    try {
+        copilot --agent=dayarc --prompt $dryrunPrompt
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Skip "Skipped — your first brief arrives at 8 PM tonight"
+}


### PR DESCRIPTION
## What

After `setup.ps1` completes, offers a dry-run PM brief preview in the terminal.

### New file: `prompts/pm-dryrun.md`
- PM brief variant: terminal output only, no email, no memory, no run tags
- Uses 7-day lookback for meaningful first-run data
- Displays formatted brief in terminal, then asks user for adjustments

### Modified: `setup.ps1`
- Adds optional dry-run prompt after "Dayarc installed ✓" banner
- Runs `copilot --agent=dayarc --prompt .../pm-dryrun.md` if user accepts
- Can decline to wait for the real 8 PM brief

## Acceptance criteria from #10
- [x] setup.ps1 prompts user to run a dry brief after install
- [x] Output rendered in terminal, no email sent, no memory written
- [x] User can correct immediately via conversation

Note: "Dry run uses warm-start lookback (depends on #9)" — the dry-run prompt hardcodes 7-day lookback independently, so this works regardless of #9 status.

Closes #10