### PR TITLE
fix: /continue push failure — force-with-lease + full fetch

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -142,6 +142,7 @@ jobs:
         if: steps.mode.outputs.mode == 'continue'
         with:
           ref: ${{ steps.resolve_pr.outputs.branch }}
+          fetch-depth: 0
 
       # ── Step 3: Gather triage context (both modes) ────────────────────────
       - name: Gather triage context
@@ -453,7 +454,11 @@ jobs:
           fi
 
           git commit -m "fix: ${SUMMARY}"
-          git push origin HEAD
+
+          # Force-with-lease: safe force push needed because git reset --soft
+          # rewrites history (squashes Copilot's intermediate commits).
+          # --force-with-lease ensures we only overwrite what we checked out.
+          git push --force-with-lease origin HEAD
 
           echo "Pushed to branch: ${{ steps.resolve_pr.outputs.branch }}"
 


### PR DESCRIPTION
## Root Cause

The \/continue\ workflow run ([#24000324930](https://github.com/YuiZhou/dayarc-agent/actions/runs/24000324930)) failed at the push step with:

\\\
! [rejected] HEAD -> fix/17-... (non-fast-forward)
\\\

Two issues:

1. **\git reset --soft\ creates non-fast-forward history** — The continue path squashes Copilot's intermediate commits via \git reset --soft \\ + \git commit\. This rewrites history, so a plain \git push\ is rejected. Fix: use \--force-with-lease\ (safe — only overwrites what we checked out).

2. **Shallow clone may break ancestry verification** — The continue checkout used default \etch-depth: 1\. With a shallow graft point, git can't prove fast-forward ancestry. Fix: use \etch-depth: 0\ for continue checkouts.

## Changes

- \coding-agent.yml\: Continue checkout gets \etch-depth: 0\
- \coding-agent.yml\: Continue push uses \git push --force-with-lease origin HEAD\

---
_Followup fix for #70._