### PR TITLE
fix: allow yuwzho to trigger /continue

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -22,7 +22,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event.label.name == 'approved') ||
       (github.event_name == 'issue_comment' &&
-       github.event.comment.user.login == 'YuiZhou' &&
+       contains(fromJSON('["YuiZhou","yuwzho"]'), github.event.comment.user.login) &&
        startsWith(github.event.comment.body, '/continue') &&
        github.event.issue.pull_request)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds yuwzho (EMU account) alongside YuiZhou as an allowed user for the /continue coding agent trigger.

Uses \contains(fromJSON('[...]'), login)\ for clean multi-user matching.