### PR TITLE
fix: use COPILOT_PAT for push — workflows permission

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -324,7 +324,7 @@ jobs:
         if: steps.detect.outputs.action == 'fix' && steps.mode.outputs.mode == 'new'
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
           DETECT_SUMMARY: ${{ steps.detect.outputs.summary }}
           ISSUE_TITLE: ${{ steps.resolve.outputs.title }}
         run: |
@@ -335,6 +335,11 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Use COPILOT_PAT for push — github.token lacks `workflows`
+          # permission needed when Copilot edits .github/workflows/ files.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
           git checkout -b "$BRANCH"
 
           BASELINE="${{ steps.baseline.outputs.sha }}"
@@ -396,9 +401,14 @@ jobs:
       - name: Push commits to PR branch
         if: steps.detect.outputs.action == 'fix' && steps.mode.outputs.mode == 'continue'
         id: push
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Use COPILOT_PAT for push — github.token lacks `workflows` permission
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Stage any cleanup from Step 7 (temp files removed) as an
           # amend to the last Copilot commit, keeping history linear.


### PR DESCRIPTION
## Problem

Coding agent /continue run [#24388728314](https://github.com/YuiZhou/dayarc-agent/actions/runs/24388728314) failed at push:

> refusing to allow a GitHub App to create or update workflow .github/workflows/coding-agent.yml without workflows permission

The default github.token lacks the workflows scope. When Copilot edits any file under .github/workflows/, the push is rejected.

## Fix

Override the git remote URL in both push steps (new + continue) to use COPILOT_PAT instead of github.token.

**Prerequisite:** Ensure the COPILOT_PAT secret has the workflow scope enabled. Go to PAT settings and add it if missing.