### PR TITLE
fix: block agent from editing workflow files, revert PAT push

### DIFF
--- a/.github/prompts/coding-prompt.md
+++ b/.github/prompts/coding-prompt.md
@@ -31,6 +31,7 @@ If the fix is genuinely impossible (e.g., requires external API changes, depends
 ## Rules
 
 - Make minimal, targeted changes — don't rewrite entire files unnecessarily
+- **NEVER modify files under `.github/workflows/` or `.github/prompts/`.** These are CI/CD infrastructure managed by the maintainer. If the fix requires workflow or prompt changes, write `unable.md` explaining what needs to change and why.
 - Feature requests: only fix if the change is trivially additive. Otherwise write `unable.md`.
 - Always reference the relevant spec/design section in `summary.md`
 - **NEVER ask the user questions or wait for input.** You are running unattended in CI. If something is ambiguous, make your best judgment or write `unable.md`.

--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -324,7 +324,7 @@ jobs:
         if: steps.detect.outputs.action == 'fix' && steps.mode.outputs.mode == 'new'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
           DETECT_SUMMARY: ${{ steps.detect.outputs.summary }}
           ISSUE_TITLE: ${{ steps.resolve.outputs.title }}
         run: |
@@ -335,11 +335,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Use COPILOT_PAT for push — github.token lacks `workflows`
-          # permission needed when Copilot edits .github/workflows/ files.
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-
           git checkout -b "$BRANCH"
 
           BASELINE="${{ steps.baseline.outputs.sha }}"
@@ -401,14 +396,9 @@ jobs:
       - name: Push commits to PR branch
         if: steps.detect.outputs.action == 'fix' && steps.mode.outputs.mode == 'continue'
         id: push
-        env:
-          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Use COPILOT_PAT for push — github.token lacks `workflows` permission
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Stage any cleanup from Step 7 (temp files removed) as an
           # amend to the last Copilot commit, keeping history linear.


### PR DESCRIPTION
Reverts the COPILOT_PAT push approach from #88 — the PAT is from yuwzho (EMU) which cannot grant workflows scope on YuiZhou's repo.

Instead: add a rule to coding-prompt.md prohibiting the agent from editing .github/workflows/ and .github/prompts/. These are CI infrastructure managed by the maintainer. If a fix requires workflow changes, the agent writes unable.md and the human handles it.

With workflow files off-limits, github.token is sufficient for all pushes.