### PR TITLE
fix: deliver skill redirects briefs to wrong repo when gh active account can't resolve target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.6] — 2026-05-29
+
+### Fixed
+- `skills/dayarc-deliver/SKILL.md` — `github-issue` target now resolves account context before delivering: it verifies the configured `repo` is reachable under the active `gh` account, switches to a matching logged-in account (by repo owner) when needed, and **fails the target with an error if the repo cannot be resolved** instead of silently redirecting the brief to a different repository. Prevents briefs from being delivered to the wrong repo when `gh` is on a non-matching active account.
+
 ## [Unreleased] — 2026-04-05
 
 ### Added

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dayarc",
   "description": "Personal daily briefing system — collects M365 and GitHub signals, learns work patterns, and delivers personalized briefs via pluggable targets (email, GitHub issues).",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Yu Zhou"
   },

--- a/skills/dayarc-deliver/SKILL.md
+++ b/skills/dayarc-deliver/SKILL.md
@@ -87,6 +87,38 @@ Creates a GitHub issue with the rendered Markdown brief.
 | `labels` | optional | Array of label names to apply |
 | `assignees` | optional | Array of GitHub usernames to assign |
 
+**Account context (do this FIRST — before idempotency or create):**
+
+`gh` may have multiple authenticated accounts, and the *active* account may not be able to see the configured `repo` (e.g., a private repo owned by a different account). You **must** ensure the active account can resolve the exact configured repo. **Never** redirect delivery to a different repository — if the configured repo cannot be resolved, fail this target with a clear error.
+
+```powershell
+$repo  = "{repo}"                 # exact owner/repo from config — do NOT change it
+$owner = $repo.Split("/")[0]
+
+# 1. Is the configured repo already resolvable under the active account?
+$ok = $false
+gh repo view $repo --json nameWithOwner 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) { $ok = $true }
+
+# 2. If not, try switching to a logged-in account matching the repo owner, then re-check.
+if (-not $ok) {
+    $accounts = gh auth status 2>&1 | Select-String "account (\S+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+    if ($accounts -contains $owner) {
+        gh auth switch --user $owner 2>&1 | Out-Null
+        gh repo view $repo --json nameWithOwner 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { $ok = $true }
+    }
+}
+
+# 3. Still unresolved → FAIL this target. Do NOT create the issue in any other repo.
+if (-not $ok) {
+    Write-Host "❌ github-issue: cannot resolve configured repo '$repo' under any logged-in account — skipping (run 'gh auth login' for owner '$owner')"
+    # skip this target, continue with others
+}
+```
+
+> ⚠️ The configured `repo` is authoritative. If it doesn't resolve, the correct outcome is a **failed target with an error**, not a fallback to a repo that happens to be visible. Silently delivering a brief to the wrong repository is a privacy and correctness bug.
+
 **Idempotency:** Before creating, search for an existing issue with the same idempotency marker:
 ```powershell
 $marker = "<!-- dayarc:brief={briefType} period={period} -->"
@@ -135,6 +167,6 @@ Render the brief as formatted markdown text in the terminal. If `locale` is not 
 1. Read `config.json → delivery` (fall back to `[{ "target": "email", "briefs": ["pm", "am", "weekly", "monthly"] }]` if absent).
 2. Filter to targets where current `briefType` is in the target's `briefs` array.
 3. Render templates (HTML for email, Markdown for github-issue).
-4. Execute each target's handler with idempotency check.
+4. Execute each target's handler with idempotency check. For `github-issue`, first ensure the active `gh` account can resolve the configured repo (switch to a matching logged-in account if needed); if it cannot be resolved, fail that target with an error — never deliver to a different repo.
 5. Report delivery summary: `✅ email: sent | ✅ github-issue: created #42` or `❌ email: Outlook not running | ✅ github-issue: created #42`.
 6. Clean up all temp files.


### PR DESCRIPTION
## Problem
On a Friday month-end run, the weekly brief was delivered to the **wrong repository**. Root cause: `gh` had multiple authenticated accounts, and the *active* account could not resolve the configured target repo (a private repo owned by a different account). The `github-issue` handler then **silently created the issue in a different, visible repo** instead of failing.

## Fix
The `github-issue` target now resolves account context **before** delivery:
- Verify the configured `repo` is reachable under the active `gh` account.
- If not, switch to a logged-in account matching the repo owner and re-check.
- If it still cannot be resolved, **fail the target with a clear error** — never redirect the brief to a different repository.

Also bumps `plugin.json` to `0.1.6` and adds a CHANGELOG entry.